### PR TITLE
proposal; never throw

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,39 @@ function hybridReaddir (path, callback) {
 hybridReaddir() instanceof bluebird // true
 ```
 
+# Error handling
+
+polygoat never throws, it passes exceptions to your callback so you don't have to.
+
+```javascript
+function delay (time, cb) {
+  // do NOT throw before return pg(...)
+  // in fact; do not write any code before
+  return pg(function (done) {
+    // inside you can throw all you want
+    if (typeof time !== 'number') {
+      throw new Error(time + ' is not a number')
+    }
+    setTimeout(done, time)
+  }, cb)
+}
+
+// delay never throws and will callback with the error instead
+delay('1000', function (err) {
+  if (err) {
+    console.log(err.toString()) // prints "Error: 1000 is not a number"
+    console.log(err.stack) // for the stack trace
+  }
+})
+
+// same when used as a promise but it shouldn't be much of a surprise
+delay('1000').catch(function (err) {
+  console.log(err.toString()) // prints "Error: 1000 is not a number"
+  console.log(err.stack) // for the stack trace
+})
+
+```
+
 # Example
 
 See [example.js](https://github.com/sonnyp/polygoat/blob/master/example.js)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ delay('1000').catch(function (err) {
   console.log(err.toString()) // prints "Error: 1000 is not a number"
   console.log(err.stack) // for the stack trace
 })
-
 ```
 
 # Example

--- a/example.js
+++ b/example.js
@@ -43,10 +43,12 @@
   })
 
   delay('1000', function (err) {
-    console.log(err)
+    if (err) {
+      console.error(err.stack)
+    }
   })
 
   delay('1000').catch(function (err) {
-    console.log(err)
+    console.error(err.stack)
   })
 }())

--- a/example.js
+++ b/example.js
@@ -27,6 +27,9 @@
   //
   function delay (time, cb) { // eslint-disable-line
     return pg(function (done) {
+      if (typeof time !== 'number') {
+        throw new Error(time + ' is not a number')
+      }
       setTimeout(done, time)
     }, cb)
   }
@@ -37,5 +40,13 @@
 
   delay(1000).then(function () {
     console.log('with polygoat, promise style')
+  })
+
+  delay('1000', function (err) {
+    console.log(err)
+  })
+
+  delay('1000').catch(function (err) {
+    console.log(err)
   })
 }())

--- a/index.js
+++ b/index.js
@@ -3,9 +3,11 @@
 
   function polygoat (fn, cb, Promise) {
     if (cb) {
-      fn(function (err, res) {
-        cb(err, res)
-      })
+      try {
+        fn(cb)
+      } catch (e) {
+        cb(e)
+      }
     } else {
       var P = Promise || global.Promise
       return new P(function (resolve, reject) {

--- a/test.js
+++ b/test.js
@@ -80,8 +80,6 @@ if (global.Promise) {
 }
 
 // with callback
-assert.throws(function () {
-  exceptionHandling(function () {
-    assert.fail('callback should not have been called')
-  })
-}, /foo/)
+exceptionHandling(function (err) {
+  assert.equal(err, 'foo')
+})


### PR DESCRIPTION
let the consumer throws but catch so that a polygoat function never throws and calls the callback with the exception as first argument instead

related discussion https://github.com/sonnyp/polygoat/issues/9

maybe a new module? (with dezalgoing as well)
