### PR TITLE
Added TypeScript type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for polygoat 1.1.4
+// Project: https://github.com/sonnyp/polygoat
+// Definitions by: Rob Moran <https://github.com/thegecko>
+
+export as namespace polygoat;
+export = polygoat;
+
+/**
+* Wraps a function to support both callback and promise styles
+* @param fn The function to wrap
+* @param cb The optional callback function
+* @returns Promise to use if a callback isn't supplied
+*/
+declare function polygoat<T>(fn: (done: (err: any, data?: T) => any) => void, cb?: (err: any, data: T) => any): Promise<T>;


### PR DESCRIPTION
A definition file to allow polygoat to be used in a TypeScript environment. Follows template specified at:

https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-function-d-ts.html

Could also be submitted to DefinitelyTyped as recommended:

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html