### PR TITLE
Support for promise multi-argument resolving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 !.gitignore
 !.npmignore
 !.travis.yml
+node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ async () => {
   console.log('done')
 }()
 
+// callbacks and promises can me resolved with more than one argument,
+// just note that in this case the promise 'then' fn will receive the arguments as a array 
+function myFn (some, arg, cb) {
+  return pg(function (done) {
+    done(null, some, arg)
+  }, cb)
+}
+myFn('result1', 'result2').then(console.log)
+// will print ['result1', 'result2']
+
 // you can also pass the Promise implementation of your choice
 var bluebird = require('bluebird')
 

--- a/index.js
+++ b/index.js
@@ -7,11 +7,13 @@
     } else {
       var P = Promise || global.Promise
       return new P(function (resolve, reject) {
-        fn(function (err, res) {
+        fn(function () {
+          var args = [].slice.call(arguments)
+          var err = args.shift()
           if (err !== null && err !== undefined) {
             reject(err)
           } else {
-            resolve(res)
+            resolve(args.length > 1 ? args : args[0])
           }
         })
       })

--- a/test.js
+++ b/test.js
@@ -12,14 +12,49 @@ function testResolve (some, arg, cb) {
   }, cb)
 }
 
+function testResolveEmpty (some, arg, cb) {
+  return pg(function (done) {
+    setTimeout(function () {
+      done(null)
+    }, 10)
+  }, cb)
+}
+
+function testResolveMultiArgs (some, arg, cb) {
+  return pg(function (done) {
+    setTimeout(function () {
+      done(null, 'yeah!', 'alright!')
+    }, 10)
+  }, cb)
+}
+
 testResolve('foo', 'bar', function (err, res) {
   assert.strictEqual(err, null)
   assert.strictEqual(res, 'yeah!')
 })
 
+testResolveEmpty('foo', 'bar', function (err, res) {
+  assert.strictEqual(err, null)
+  assert.strictEqual(res, undefined)
+})
+
+testResolveMultiArgs('foo', 'bar', function (err, res1, res2) {
+  assert.strictEqual(err, null)
+  assert.strictEqual(res1, 'yeah!')
+  assert.strictEqual(res2, 'alright!')
+})
+
 if (global.Promise) {
   testResolve('foo', 'bar').then(function (res) {
     assert.strictEqual(res, 'yeah!')
+  })
+
+  testResolveEmpty('foo', 'bar').then(function (res) {
+    assert.strictEqual(res, undefined)
+  })
+
+  testResolveMultiArgs('foo', 'bar').then(function (res) {
+    assert.deepEqual(res, ['yeah!', 'alright!'])
   })
 
   testResolve('foo', 'bar').catch(function () {
@@ -43,7 +78,7 @@ testReject(function (err, res) {
 if (global.Promise) {
   testReject().then(function () {
     assert.fail('promise should not have fulfilled')
-  })
+  }).catch(function () {})
 
   testReject().catch(function (err) {
     assert.strictEqual(err, 'error!!')


### PR DESCRIPTION
Hello, thanks for this nice library.

This PR makes polygoat to checks if a promise is going to resolve with more than one argument, and if that's the case, resolve them as an array. New tests and documentation are provided.

NOTE: Callback style is already working multi-argument since the callback is invoked as it is, at least pulling from Github, not from npm package (it must be outdated).